### PR TITLE
fix: symbolicLink error

### DIFF
--- a/lib/async.js
+++ b/lib/async.js
@@ -56,13 +56,13 @@ function rm(path, cb) {
     });
   });
   function _delFile(path, cb) {
-    Fs.stat(path, function (e, st) {
+    Fs.lstat(path, function (e, st) {
       if (e) {
         return cb(e);
       }
       if (st.isDirectory()) {
         rm(path, cb);
-      } else if (st.isFile()) {
+      } else if (st.isFile() || st.isSymbolicLink()) {
         Fs.unlink(path, function (err) {
           if (err && err.code === 'ENOENT') {
             return cb(null);
@@ -203,7 +203,7 @@ function walk(path, expr, cb, done, _each) {
   if (!done) {
     done = dummy;
   }
-  Fs.stat(path, function (err, stat) {
+  Fs.lstat(path, function (err, stat) {
     if (err) {
       // empty link file
       if (err.code === 'ENOENT') {


### PR DESCRIPTION
Fs.rmdir will throw an error  when the file is a symbolic link cause Fs.state regards symbolic link as a directory